### PR TITLE
Fix version as same as 17media/api

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,5 @@ go 1.13
 
 require (
 	github.com/spaolacci/murmur3 v1.1.0
-	github.com/willf/bitset v1.1.10
+	github.com/willf/bitset v1.1.4-0.20170905002639-1a37ad96e8c1
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
-github.com/willf/bitset v1.1.10 h1:NotGKqX0KwQ72NUzqrjZq5ipPNDQex9lo3WpaS8L2sc=
-github.com/willf/bitset v1.1.10/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
+github.com/willf/bitset v1.1.4-0.20170905002639-1a37ad96e8c1 h1:6YAC9w0ne4nSsR9mdO1Ekvdhz4KfKOtao8LXdctGTgQ=
+github.com/willf/bitset v1.1.4-0.20170905002639-1a37ad96e8c1/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=


### PR DESCRIPTION
## Description
Keep dependencies version as same as `17media/api`.

## Motivation and Context
There was no dependencies management in this repo and we should follow the original version via checking [`vendor.json`](https://github.com/17media/api/blob/master/vendor/vendor.json#L2744).